### PR TITLE
Build and packaging scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
-os
-src/__pycache__
+dist
+build
+*.spec
+__pycache__

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+rm -rf dist
+rm -rf build
+pyinstaller --onefile ../src/main.py

--- a/scripts/build-win.bat
+++ b/scripts/build-win.bat
@@ -1,0 +1,3 @@
+del  -rf dist
+del build
+pyinstaller --onefile ../src/main.py


### PR DESCRIPTION
When the build script is used, running the compiled binary displays this error:

```
ImportError: libgssapi_krb5.so.2: cannot open shared object file: No such file or directory
```
I don't know how to fix this.