### PR TITLE
feat: add a CI build action 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ on:
   push:
 jobs:
   build:
+    permissions: write-all
     runs-on: "ubuntu-latest"
     strategy:
       fail-fast: false
@@ -14,7 +15,7 @@ jobs:
     - run: pyinstaller --onefile src/main.py
     - run: mv dist/main catalyst
     - run: zip catalyst-browser catalyst
-    - name: Create Release
+    - name: Create release
       id: create_release
       uses: actions/create-release@v1
       env:
@@ -24,7 +25,7 @@ jobs:
         release_name: Release ${{ github.ref }}
         draft: false
         prerelease: false
-    - name: Upload Release Asset
+    - name: Upload release asset
       id: upload-release-asset 
       uses: actions/upload-release-asset@v1
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,14 +16,11 @@ jobs:
     - run: mv dist/main catalyst
     - run: zip catalyst-browser catalyst
 
-    - id: tag
-      uses: dawidd6/action-get-tag@v1
-
     - name: Create release
       id: create_release
       uses: actions/create-release@v1
       with:
-        tag_name: ${{ steps.tag.outputs.tag }}
+        tag_name: ${GITHUB_REF##*/}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: 3.7
-    - run: sudo apt install libgssapi-krb5-2
+    - run: sudo apt install -y libgssapi-krb5-2
     - run: pip install -r requirements.txt pyinstaller
     - run: pyinstaller src/main.py
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,11 @@ jobs:
     - run: sudo apt install -y libgssapi-krb5-2
     - run: pip install -r requirements.txt pyinstaller
     - run: pyinstaller --onefile src/main.py
-    - uses: actions/upload-artifact@v2
+    - name: Upload binaries to release
+      uses: svenstaro/upload-release-action@v2
       with:
-        path: dist/*
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: dist/*
+        asset_name: catalyst
+        tag: ${{ github.ref }}
+        overwrite: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+on:
+  push:
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - run: sudo apt install libgssapi-krb5-2
+    - run: pip install -r requirements.txt pyinstaller
+    - run: pyinstaller src/main.py
+    - uses: actions/upload-artifact@v2
+      with:
+        path: dist/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,15 +10,14 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: 3.7
-    - run: sudo apt install -y libgssapi-krb5-2
     - run: pip install -r requirements.txt pyinstaller
     - run: pyinstaller --onefile src/main.py
-    - run: ls dist
+    - run: mv dist/main dist/catalyst
     - name: Upload binaries to release
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: dist/*
+        file: dist/catalyst
         asset_name: catalyst
         tag: ${{ github.ref }}
         overwrite: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,11 +20,6 @@ jobs:
       uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        draft: false
-        prerelease: false
     - name: Upload release asset
       id: upload-release-asset 
       uses: actions/upload-release-asset@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,17 @@ jobs:
     - run: pyinstaller --onefile src/main.py
     - run: mv dist/main catalyst
     - run: zip catalyst-browser catalyst
+    - uses: mad9000/actions-find-and-replace-string@2
+      id: tagreplace
+      with:
+        source: ${{ github.ref }}
+        find: 'refs/'
+        replace: ''
     - name: Create release
       id: create_release
       uses: actions/create-release@v1
       with:
-        tag_name: ${{ github.ref }}
+        tag_name: ${{ steps.tagreplace.outputs.value }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Upload release asset

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       id: create_release
       uses: actions/create-release@v1
       with:
-        tag_name: ${GITHUB_REF##*/}
+        tag_name: ${{ ${GITHUB_REF##*/} }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
     - run: sudo apt install -y libgssapi-krb5-2
     - run: pip install -r requirements.txt pyinstaller
     - run: pyinstaller --onefile src/main.py
+    - run: ls dist
     - name: Upload binaries to release
       uses: svenstaro/upload-release-action@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,25 @@ jobs:
         python-version: 3.7
     - run: pip install -r requirements.txt pyinstaller
     - run: pyinstaller --onefile src/main.py
-    - run: mv dist/main dist/catalyst
-    - name: Upload binaries to release
-      uses: svenstaro/upload-release-action@v2
+    - run: mv dist/main catalyst
+    - run: zip catalyst-browser catalyst
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: dist/catalyst
-        asset_name: catalyst
-        tag: ${{ github.ref }}
-        overwrite: true
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: false
+    - name: Upload Release Asset
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }} 
+        asset_path: ./catalyst-browser.zip
+        asset_name: catalyst-browser.zip
+        asset_content_type: application/zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,19 +15,18 @@ jobs:
     - run: pyinstaller --onefile src/main.py
     - run: mv dist/main catalyst
     - run: zip catalyst-browser catalyst
-    - uses: mad9000/actions-find-and-replace-string@2
-      id: tagreplace
-      with:
-        source: ${{ github.ref }}
-        find: 'refs/'
-        replace: ''
+
+    - id: tag
+      uses: dawidd6/action-get-tag@v1
+
     - name: Create release
       id: create_release
       uses: actions/create-release@v1
       with:
-        tag_name: ${{ steps.tagreplace.outputs.value }}
+        tag_name: ${{ steps.tag.outputs.tag }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Upload release asset
       id: upload-release-asset 
       uses: actions/upload-release-asset@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,15 @@ jobs:
     - run: mv dist/main catalyst
     - run: zip catalyst-browser catalyst
 
+    - name: Get the version
+      id: get_version
+      run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+
     - name: Create release
       id: create_release
       uses: actions/create-release@v1
       with:
-        tag_name: ${{ ${GITHUB_REF##*/} }}
+        tag_name: ${{ steps.get_version.outputs.VERSION }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,11 +2,9 @@ on:
   push:
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: "ubuntu-latest"
     strategy:
       fail-fast: false
-      matrix:
-        os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
@@ -14,7 +12,7 @@ jobs:
         python-version: 3.7
     - run: sudo apt install -y libgssapi-krb5-2
     - run: pip install -r requirements.txt pyinstaller
-    - run: pyinstaller src/main.py
+    - run: pyinstaller --onefile src/main.py
     - uses: actions/upload-artifact@v2
       with:
         path: dist/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
     - name: Create release
       id: create_release
       uses: actions/create-release@v1
+      with:
+        tag_name: ${{ github.ref }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Upload release asset


### PR DESCRIPTION
A big gotcha with using Pyinstaller is that outputed executables are pretty large. (>150MB) But then again, Electron makes executables that are just as bloated ¯\\\_(ツ)_/¯

Also, newly made releases don't use tags for some reason?? Maybe it's just something to do with forks 