### PR TITLE
fix: Add proper release creation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,4 @@
+- name: Bundle Catalyst
 on:
   push:
 jobs:
@@ -16,15 +17,15 @@ jobs:
     - run: mv dist/main catalyst
     - run: zip catalyst-browser catalyst
 
-    - name: Get the version
-      id: get_version
-      run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+    - name: Make a tag for the release because GitHub Actions is bad at it's own job
+      id: tag_version
+      uses: mathieudutour/github-tag-action@v6.1
 
     - name: Create release
       id: create_release
       uses: actions/create-release@v1
       with:
-        tag_name: ${{ steps.get_version.outputs.VERSION }}
+        tag_name: ${{ steps.tag_version.outputs.new_tag }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,8 @@ jobs:
     - name: Make a tag for the release because GitHub Actions is bad at it's own job
       id: tag_version
       uses: mathieudutour/github-tag-action@v6.1
-
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Create release
       id: create_release
       uses: actions/create-release@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,3 @@
-- name: Bundle Catalyst
 on:
   push:
 jobs:


### PR DESCRIPTION
The CI build step works properly now, and it should also come with semantic versioning (props to github marketplace)